### PR TITLE
Fix compatibility with Claude.ai Extended Thinking feature

### DIFF
--- a/content.js
+++ b/content.js
@@ -103,10 +103,9 @@ async function extractMessageContent(message) {
   userProvidedFileContent = await getUserProvidedFileContent(message);
   contents = contents.concat(userProvidedFileContent);
   COUNTER += 1;
-  // Find the main grid container
-  // const gridContainer = message.querySelector(CLAUDE_GRID_CONTAINER_CLASSES) || message.querySelector(USER_GRID_CONTAINER_CLASSES);
-  const gridContainer = message.querySelector("div:has(> p)");
-  // const gridContainer = message.querySelector('.grid-cols-1.grid.gap-2\\.5');
+  // Find the main grid container, excluding the thinking section
+  const allCandidates = message.querySelectorAll("div:has(> p)");
+  const gridContainer = Array.from(allCandidates).find(el => !el.closest('.overflow-hidden.shrink-0'));
 
   if (gridContainer) {
     // Get all direct children of the grid container
@@ -399,7 +398,9 @@ function addButtonsToMessages() {
         const formattedConvoAsTextBlock = formattedConversationHistory.join(SPLITTER);
         createHistoryModal(formattedConvoAsTextBlock);
       });
-      const messageDiv = response.querySelector('div > div.grid-cols-1.grid');
+      // Find grid element that's NOT in the thinking section (which has class overflow-hidden shrink-0)
+      const allGrids = response.querySelectorAll('div.grid-cols-1.grid');
+      const messageDiv = Array.from(allGrids).find(g => !g.closest('.overflow-hidden.shrink-0'));
       if (messageDiv) {
         messageDiv.insertAdjacentElement('afterend', button);
       } else {


### PR DESCRIPTION
## Summary
- Fix button being injected into the hidden thinking section instead of visible response area
- Fix content extraction capturing thinking text instead of actual response content

Both issues caused by Claude.ai's new "Extended Thinking" feature, which wraps thinking content in a collapsible section with class `overflow-hidden shrink-0`.

## Test plan
- [x] Verified button appears below Claude's response (not hidden)
- [x] Verified conversation export contains actual response text, not thinking content
- [x] Tested with multi-turn conversations